### PR TITLE
Update AppTopbar.vue

### DIFF
--- a/frontend/src/components/navigation/bars/AppTopbar.vue
+++ b/frontend/src/components/navigation/bars/AppTopbar.vue
@@ -160,7 +160,7 @@ export default {
 </script>
 
 <template>
-    <Menubar :model="items" class="h-16 w-full px-8 sm:px-8 transition-[left] duration-[var(--layout-section-transition-duration)] flex items-center !rounded-none" :pt="{ rootList: { class: 'w-full flex justify-end rounded-none' } }">
+    <Menubar :model="items" class="h-16 w-full px-8 sm:px-8 transition-[left] duration-[\[var(--layout-section-transition-duration)\]] flex items-center !rounded-none" :pt="{ rootList: { class: 'w-full flex justify-end rounded-none' } }">
         <template #start>
             <router-link to="/" class="">
                 <img src="/images/logo-no-slogan.svg" alt="logo" class="max-w-[10rem] md:max-h-[3rem]" />


### PR DESCRIPTION
Build error fix:
warn - The class `duration-[var(--layout-section-transition-duration)]` is ambiguous and matches multiple utilities.
warn - If this is content and not a class, replace it with `duration-&lsqb;var(--layout-section-transition-duration)&rsqb;` to silence this warning.

![image](https://github.com/user-attachments/assets/a63e0f72-a20a-4064-bad2-884e51f38c4e)
